### PR TITLE
Fix grails wrapper not working on Cygwin

### DIFF
--- a/shell/grailsw
+++ b/shell/grailsw
@@ -102,6 +102,7 @@ fi
 if $cygwin ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     JAVACMD=`cygpath --unix "$JAVACMD"`
+    JAR_PATH=`cygpath --path --mixed "$JAR_PATH"`
 
     # We build the pattern for arguments to be converted via cygpath
     ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`


### PR DESCRIPTION
Fix this error on Cygwin:

```
Error: Unable to access jarfile /cygdrive/c/Users/abcfy/projects/mes/mes-web/grails-wrapper.jar
```