### PR TITLE
Fixes problem with Grails wrapper Starter app

### DIFF
--- a/starter/src/main/java/grails/init/Start.java
+++ b/starter/src/main/java/grails/init/Start.java
@@ -73,10 +73,9 @@ public class Start {
         final String jarFileName = PROJECT_NAME + "-" + version;
         final String jarFileExtension = ".jar";
 
-        if (WRAPPER_DIR.mkdirs()) {
+        if (WRAPPER_DIR.exists() || WRAPPER_DIR.mkdirs()) {
             try {
                 File downloadedJar = File.createTempFile(jarFileName, jarFileExtension);
-
                 final String wrapperUrl = getGrailsCoreArtifactoryBaseUrl() + WRAPPER_PATH + "/" + version + "/" + jarFileName + jarFileExtension;
                 HttpURLConnection conn = createHttpURLConnection(wrapperUrl);
                 success = downloadWrapperJar(downloadedJar, conn.getInputStream());


### PR DESCRIPTION
Incorrect if condition where it checks if the wrapper download directory exists then it does not download the wrapper fat JAR

Signed-off-by: Puneet Behl <behlp@objectcomputing.com>