### PR TITLE
Grails Wrapper 3.1.0-M1 for Grails 5.3.4+: Class not found exception property source property resolver

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-projectVersion=3.0.0-SNAPSHOT
+projectVersion=3.1.0.M1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-projectVersion=3.1.0.M1
+projectVersion=3.1.0-SNAPSHOT

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 include 'starter'
 include 'wrapper'
 
-project(":wrapper").name = "grails5-wrapper"
+project(":wrapper").name = "grails5_3_4-wrapper"

--- a/starter/build.gradle
+++ b/starter/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 jar {
-    archiveName = "grails-wrapper.jar"
+    archiveFileName = "grails-wrapper.jar"
     manifest {
         attributes 'Main-Class': 'grails.init.Start'
     }

--- a/starter/src/main/java/grails/init/Start.java
+++ b/starter/src/main/java/grails/init/Start.java
@@ -21,7 +21,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 public class Start {
 
-    private static final String PROJECT_NAME = "grails5-wrapper";
+    private static final String PROJECT_NAME = "grails5_3_4-wrapper";
     private static final String WRAPPER_PATH = "/org/grails/" + PROJECT_NAME;
     private static final String DEFAULT_GRAILS_CORE_ARTIFACTORY_BASE_URL = "https://repo.grails.org/grails/core";
     private static final File WRAPPER_DIR = new File(System.getProperty("user.home") + "/.grails/wrapper");

--- a/wrapper/build.gradle
+++ b/wrapper/build.gradle
@@ -94,6 +94,7 @@ dependencies {
     implementation "org.codehaus.groovy:groovy:$groovyVersion"
     implementation "org.springframework.boot:spring-boot-cli:$springBootVersion"
     implementation "org.codehaus.groovy:groovy-ant:$groovyVersion"
+    implementation "io.micronaut:micronaut-inject-groovy:$micronautInjectGroovyVersion"
 }
 
 jar {

--- a/wrapper/gradle.properties
+++ b/wrapper/gradle.properties
@@ -1,5 +1,5 @@
-grailsVersion=5.0.0.M1
-grailsGradlePluginVerison=5.0.0.M2
+grailsVersion=5.0.0
+grailsGradlePluginVerison=5.0.0
 groovyVersion=3.0.5
 springBootVersion=2.5.0
 micronautInjectGroovyVersion=3.8.8

--- a/wrapper/gradle.properties
+++ b/wrapper/gradle.properties
@@ -2,3 +2,4 @@ grailsVersion=5.0.0.M1
 grailsGradlePluginVerison=5.0.0.M2
 groovyVersion=3.0.5
 springBootVersion=2.5.0
+micronautInjectGroovyVersion=3.8.8


### PR DESCRIPTION
For Grails 5.3.4 and above

Resolve ClassNotFoundException: io.micronaut.context.env.PropertySourcePropertyResolver Exception

Update project version to 3.1.0-M1 and project name to grails5_3_4-wrapper so that we can release a wrapper version for Grails 5.3.4 and above and not break the wrapper for prior Grails 5 versions.

This only applies to Grails 5.3.4 and later which upgraded to snakeyaml 2

Resolves https://github.com/grails/grails-core/issues/13327
