### PR TITLE
Grails Wrapper 4.0.0.M1 for Grails 6

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,11 +2,11 @@ name: Java CI
 on:
   push:
     branches:
-      - 2.0.x
+      - '[1-9]+.[0-9]+.x'
       - master
   pull_request:
     branches:
-      - 2.0.x
+      - '[1-9]+.[0-9]+.x'
       - master
 jobs:
   build:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11']
+        java: ['8']
     env:
       WORKSPACE: ${{ github.workspace }}
       GRADLE_OPTS: -Xmx1500m -Dfile.encoding=UTF-8

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8']
+        java: ['11']
     env:
       WORKSPACE: ${{ github.workspace }}
       GRADLE_OPTS: -Xmx1500m -Dfile.encoding=UTF-8

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,10 +30,10 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Run Assemble
-        if: success() && github.event_name == 'push' && matrix.java == '8'
+        if: success() && github.event_name == 'push' && matrix.java == '11'
         run: ./gradlew assemble
       - name: Publish to repo.grails.org
-        if: success() && github.event_name == 'push' && matrix.java == '8'
+        if: success() && github.event_name == 'push' && matrix.java == '11'
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - master
-      - 2.0.x
+      - '[1-9]+.[0-9]+.x'
   workflow_dispatch:
 jobs:
   release_notes:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8']
+        java: ['11']
     env:
       GIT_USER_NAME: puneetbehl
       GIT_USER_EMAIL: behlp@objectcomputing.com

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11']
+        java: ['8']
     env:
       GIT_USER_NAME: puneetbehl
       GIT_USER_EMAIL: behlp@objectcomputing.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
   - $HOME/.gradle
 jdk:
-- openjdk8
+- openjdk11
 script: ./travis-build.sh
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
   - $HOME/.gradle
 jdk:
-- openjdk11
+- openjdk8
 script: ./travis-build.sh
 env:
   global:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-projectVersion=3.0.0-SNAPSHOT
+projectVersion=4.0.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-projectVersion=4.0.0-SNAPSHOT
+projectVersion=4.0.0.M1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 include 'starter'
 include 'wrapper'
 
-project(":wrapper").name = "grails5-wrapper"
+project(":wrapper").name = "grails6-wrapper"

--- a/starter/build.gradle
+++ b/starter/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'java'
 
 jar {
-    archiveName = "grails-wrapper.jar"
+    archiveFileName = "grails-wrapper.jar"
     manifest {
         attributes 'Main-Class': 'grails.init.Start'
     }
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = "1.11"
+targetCompatibility = "1.11"

--- a/starter/build.gradle
+++ b/starter/build.gradle
@@ -7,5 +7,5 @@ jar {
     }
 }
 
-sourceCompatibility = "1.11"
-targetCompatibility = "1.11"
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11

--- a/starter/src/main/java/grails/init/Start.java
+++ b/starter/src/main/java/grails/init/Start.java
@@ -21,7 +21,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 public class Start {
 
-    private static final String PROJECT_NAME = "grails5-wrapper";
+    private static final String PROJECT_NAME = "grails6-wrapper";
     private static final String WRAPPER_PATH = "/org/grails/" + PROJECT_NAME;
     private static final String DEFAULT_GRAILS_CORE_ARTIFACTORY_BASE_URL = "https://repo.grails.org/grails/core";
     private static final File WRAPPER_DIR = new File(System.getProperty("user.home") + "/.grails/wrapper");

--- a/wrapper/build.gradle
+++ b/wrapper/build.gradle
@@ -83,8 +83,8 @@ configurations {
     }
 }
 
-sourceCompatibility = "1.11"
-targetCompatibility = "1.11"
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
 
 repositories {
     mavenCentral()

--- a/wrapper/build.gradle
+++ b/wrapper/build.gradle
@@ -14,9 +14,9 @@ buildscript {
         }
     }
     dependencies {
-        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVerison"
-        classpath 'io.spring.gradle:dependency-management-plugin:1.0.11.RELEASE'
-        classpath "io.github.gradle-nexus:publish-plugin:1.1.0"
+        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
+        classpath 'io.spring.gradle:dependency-management-plugin:1.1.6'
+        classpath "io.github.gradle-nexus:publish-plugin:2.0.0"
         classpath "com.bmuschko:gradle-nexus-plugin:2.3.1"
     }
 }
@@ -25,7 +25,7 @@ group 'org.grails'
 version project.projectVersion
 
 ext.pomInfo = {
-    delegate.name 'Grails 5 Wrapper'
+    delegate.name 'Grails 6 Wrapper'
     delegate.description 'The Grails Wrapper Project'
     delegate.url 'https://github.com/grails/grails-wrapper'
 
@@ -74,10 +74,17 @@ ext {
 
 configurations {
     groovyDoc.extendsFrom runtimeClasspath
+
+    all {
+        resolutionStrategy.dependencySubstitution {
+            //update fields plugin used by scaffolding
+            substitute(module("org.codehaus.plexus:plexus-sec-dispatcher:2.0")).with(module("org.sonatype.plexus:plexus-sec-dispatcher:1.4"))
+        }
+    }
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = "1.11"
+targetCompatibility = "1.11"
 
 repositories {
     mavenCentral()
@@ -94,6 +101,7 @@ dependencies {
     implementation "org.codehaus.groovy:groovy:$groovyVersion"
     implementation "org.springframework.boot:spring-boot-cli:$springBootVersion"
     implementation "org.codehaus.groovy:groovy-ant:$groovyVersion"
+    implementation "io.micronaut:micronaut-inject-groovy:$micronautInjectGroovyVersion"
 }
 
 jar {
@@ -105,6 +113,8 @@ jar {
     manifest {
         attributes 'Main-Class': 'grails.init.RunCommand'
     }
+
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 
 task sourcesJar(type: Jar) {

--- a/wrapper/gradle.properties
+++ b/wrapper/gradle.properties
@@ -1,5 +1,5 @@
-grailsVersion=6.2.0
-grailsGradlePluginVersion=6.1.2
+grailsVersion=6.0.0
+grailsGradlePluginVersion=6.0.0
 groovyVersion=3.0.21
-springBootVersion=2.7.18
+springBootVersion=2.7.12
 micronautInjectGroovyVersion=3.10.4

--- a/wrapper/gradle.properties
+++ b/wrapper/gradle.properties
@@ -1,4 +1,5 @@
-grailsVersion=5.0.0.M1
-grailsGradlePluginVerison=5.0.0.M2
-groovyVersion=3.0.5
-springBootVersion=2.5.0
+grailsVersion=6.2.0
+grailsGradlePluginVersion=6.1.2
+groovyVersion=3.0.21
+springBootVersion=2.7.18
+micronautInjectGroovyVersion=3.10.4

--- a/wrapper/src/main/groovy/grails/init/RunCommand.groovy
+++ b/wrapper/src/main/groovy/grails/init/RunCommand.groovy
@@ -11,17 +11,25 @@ import org.springframework.boot.cli.compiler.grape.RepositoryConfiguration
  */
 class RunCommand {
 
+    static final String DEFAULT_GRAILS_SHELL_VERSION = '6.1.2'
+
     static void main(String[] args) {
 
         Properties props = new Properties()
         String grailsVersion
+        String grailsShellVersion
         String groovyVersion
         try {
             props.load(new FileInputStream("gradle.properties"))
             grailsVersion = props.getProperty("grailsVersion")
+            grailsShellVersion = props.getProperty("grailsShellVersion")
             groovyVersion = props.getProperty("groovyVersion")
         } catch (IOException e) {
             throw new RuntimeException("Could not determine grails version due to missing properties file")
+        }
+
+        if(!grailsShellVersion) {
+            grailsShellVersion = DEFAULT_GRAILS_SHELL_VERSION
         }
 
         GroovyClassLoader groovyClassLoader = new GroovyClassLoader(RunCommand.classLoader)
@@ -32,7 +40,13 @@ class RunCommand {
         }
 
         MavenResolverGrapeEngine grapeEngine = MavenResolverGrapeEngineFactory.create(groovyClassLoader, repositoryConfigurations, new DependencyResolutionContext(), false)
-        grapeEngine.grab([:], [group: "org.grails", module: "grails-shell", version: grailsVersion])
+        try {
+            grapeEngine.grab([:], [group: "org.grails", module: "grails-shell", version: grailsVersion])
+        }
+        catch(dependencyResolutionException){
+            // Try grails shell version from gradle.properties or default
+            grapeEngine.grab([:], [group: "org.grails", module: "grails-shell", version: grailsShellVersion])
+        }
 
         ClassLoader previousClassLoader = Thread.currentThread().contextClassLoader
         Thread.currentThread().setContextClassLoader(groovyClassLoader)

--- a/wrapper/src/main/groovy/grails/init/RunCommand.groovy
+++ b/wrapper/src/main/groovy/grails/init/RunCommand.groovy
@@ -1,8 +1,9 @@
 package grails.init
 
-import org.springframework.boot.cli.compiler.grape.AetherGrapeEngine
-import org.springframework.boot.cli.compiler.grape.AetherGrapeEngineFactory
+
 import org.springframework.boot.cli.compiler.grape.DependencyResolutionContext
+import org.springframework.boot.cli.compiler.grape.MavenResolverGrapeEngine
+import org.springframework.boot.cli.compiler.grape.MavenResolverGrapeEngineFactory
 import org.springframework.boot.cli.compiler.grape.RepositoryConfiguration
 
 /**
@@ -30,7 +31,7 @@ class RunCommand {
             repositoryConfigurations.add(new RepositoryConfiguration("JFrog OSS snapshot repo", new URI("https://oss.jfrog.org/oss-snapshot-local"), true))
         }
 
-        AetherGrapeEngine grapeEngine = AetherGrapeEngineFactory.create(groovyClassLoader, repositoryConfigurations, new DependencyResolutionContext(), false)
+        MavenResolverGrapeEngine grapeEngine = MavenResolverGrapeEngineFactory.create(groovyClassLoader, repositoryConfigurations, new DependencyResolutionContext(), false)
         grapeEngine.grab([:], [group: "org.grails", module: "grails-shell", version: grailsVersion])
 
         ClassLoader previousClassLoader = Thread.currentThread().contextClassLoader


### PR DESCRIPTION
Grails 6 must have a profile defined in build.gradle dependencies to use wrapper and/or grails-shell CLI such as:

profile ("org.grails.profiles:web")

Resolves https://github.com/grails/grails-core/issues/13327