### PR TITLE
Add missing groovy-templates dependency

### DIFF
--- a/wrapper/build.gradle
+++ b/wrapper/build.gradle
@@ -102,6 +102,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-cli:$springBootVersion"
     implementation "org.codehaus.groovy:groovy-ant:$groovyVersion"
     implementation "io.micronaut:micronaut-inject-groovy:$micronautInjectGroovyVersion"
+    implementation "org.apache.groovy:groovy-templates:$groovyVersion"
 }
 
 jar {


### PR DESCRIPTION
In Grails 6.2.3 when trying to make a scaffold Controller I get
```

grails> generate-all demo.Todo
| Error Command [generate-all] error: groovy/text/Template (Use --stacktrace to see the full trace)
```

in a brand new application where all I have done previously is
`grails> create-domain-class Todo`

The same change was applied to the Grails 7 branches in https://github.com/grails/grails-wrapper/pull/25/files

After this PR has been merged, we will release grails-wrapper 4.0.2 and it will be possible to update an existing Grails 6.2.x application using
`
./grailsw update-wrapper`

Users who have not run `./grailsw` with Grails 6 also always get the newest version for the Grails version the first time they run ./grailsw` 
https://central.sonatype.com/artifact/org.grails/grails6-wrapper